### PR TITLE
link to the new mmi plan details page

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,7 +41,8 @@ function render_plans(plans, gid) {
 		var p = plans[i];
 
 		//plan_link = 'http://www.mmi.gov.il/IturTabot/taba2.asp?Gush=' + p.gush_id + '&MisTochnit=' + escape(p.number)
-		plan_link = 'http://mmi.gov.il/IturTabot/taba4.asp?kod=3000&MsTochnit=' + escape(p.number);
+		//plan_link = 'http://mmi.gov.il/IturTabot/taba4.asp?kod=3000&MsTochnit=' + escape(p.number);
+		plan_link = p.details_link;
 		
 		out+='<tr style="vertical-align:top" class="item">' +
 			 '	<td><b>' + [p.day, p.month, p.year].join('/') + '</b></td>' +


### PR DESCRIPTION
There's a new plan details url with the new MMI site.
This time a few parameters need to be sent, so I decided to save the whole url and just redirect to it...

This accompanies opentaba-server pull request https://github.com/niryariv/opentaba-server/pull/63 of the new site scraper
