### PR TITLE
Another fix for server issue #103

### DIFF
--- a/templates/plans.html
+++ b/templates/plans.html
@@ -61,7 +61,7 @@
                     <a href="{{this}}" target="_blank" rel="tooltip" title="נספחים" style="font-size:14px;"><i class="icon-folder-open"></i></a>
                 {{/each}}
                 {{#each files_link}}
-                    <a href="http://mmi.gov.il{{this}}" rel="tooltip" title="קבצי ממג" style="font-size:14px;"><i class="icon-download-alt"></i></a>
+                    <a href="{{this}}" rel="tooltip" title="קבצי ממג" style="font-size:14px;"><i class="icon-download-alt"></i></a>
                 {{/each}}
                 {{#if mavat_code}}
                     <a href="{{../../base_api_url}}plan/{{plan_id}}/mavat" target="_blank" rel="tooltip" title="מבא&quot;ת" style="font-size:14px;"><i class="icon-link"></i></a>


### PR DESCRIPTION
Don't prepend base mmi url as they began providing a full url (this fixes the mamag links which were prepended with the domain name as part of the plan template and not while scraping).